### PR TITLE
Rename threads parameter to n_threads.

### DIFF
--- a/src/bin/kaleid0sc0pe/api.cpp
+++ b/src/bin/kaleid0sc0pe/api.cpp
@@ -1,5 +1,4 @@
 #include "frei0r.hpp"
-
 #include "ikaleidoscope.h"
 
 class kaleid0sc0pe : public frei0r::filter
@@ -66,7 +65,7 @@ public:
                                 "multithreaded",
                                 "set to true to enable multithreaded calculation. default true");
         register_param(m_threads,
-                                "threads",
+                                "n_threads",
                                 "the number of threads to use, if 0 then autocalculate otherwise value * 32. default 0");
 
 
@@ -165,4 +164,4 @@ private:
     std::unique_ptr<libkaleidoscope::IKaleidoscope> m_kaleidoscope;
 };
 
-frei0r::construct<kaleid0sc0pe> plugin("Kaleid0sc0pe", "Applies a kaleidoscope effect to a source image", "Brendan Hack", 1, 0, F0R_COLOR_MODEL_RGBA8888);
+frei0r::construct<kaleid0sc0pe> plugin("Kaleid0sc0pe", "Applies a kaleidoscope effect to a source image", "Brendan Hack", 1, 1, F0R_COLOR_MODEL_RGBA8888);

--- a/src/kdenlive/kaleid0sc0pe.xml
+++ b/src/kdenlive/kaleid0sc0pe.xml
@@ -44,7 +44,7 @@
 		<parameter type="bool" name="multithreaded" default="1">
 		<name>Multithreaded</name>
 	</parameter>
-		<parameter type="constant" name="threads" default="0" min="0" max="32" factor="32">
+		<parameter type="constant" name="n_threads" default="0" min="0" max="32" factor="32">
 		<name>Thread count</name>
 	</parameter>
 </effect>


### PR DESCRIPTION
The MLT framework was interpreting this parameter and slicing frames to process them in parallel which caused intense corruption of the effect since it requires full frame access. Renaming the parameter prevents this from occuring.